### PR TITLE
Fixed indexing bug with torch 1.5.0

### DIFF
--- a/Chapter06/02_dqn_pong.py
+++ b/Chapter06/02_dqn_pong.py
@@ -99,7 +99,7 @@ def calc_loss(batch, net, tgt_net, device="cpu"):
         states, copy=False)).to(device)
     next_states_v = torch.tensor(np.array(
         next_states, copy=False)).to(device)
-    actions_v = torch.tensor(actions).to(device)
+    actions_v = torch.tensor(actions, dtype=torch.int64).to(device)
     rewards_v = torch.tensor(rewards).to(device)
     done_mask = torch.BoolTensor(dones).to(device)
 


### PR DESCRIPTION
`RuntimeError: index 12884901891 is out of bounds for dimension 1 with size 6`

I kept encountering runtime errors when attempting to run 02_dqn_pong.py with torch==1.5.0. I realized that this was just a problem with torch.gather and the index datatype being int32. This should allow the program to run on torch 1.5.0 without breaking compatibility to older versions. 