### PR TITLE
add more hints in the main

### DIFF
--- a/Chapter07/06_cartpole.py
+++ b/Chapter07/06_cartpole.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         epsilon=1, selector=selector)
     agent = ptan.agent.DQNAgent(net, selector)
     exp_source = ptan.experience.ExperienceSourceFirstLast(
-        env, agent, gamma=GAMMA)
+        env, agent, gamma=GAMMA, steps_count=1)
     buffer = ptan.experience.ExperienceReplayBuffer(
         exp_source, buffer_size=REPLAY_SIZE)
     optimizer = optim.Adam(net.parameters(), LR)
@@ -82,8 +82,8 @@ if __name__ == "__main__":
 
         for reward, steps in exp_source.pop_rewards_steps():
             episode += 1
-            print("%d: episode %d done, reward=%.3f, epsilon=%.2f" % (
-                step, episode, reward, selector.epsilon))
+            print("%d: episode %d done in %d steps, reward=%.3f, epsilon=%.2f" % (
+                step, episode, steps, reward, selector.epsilon))
             solved = reward > 150
         if solved:
             print("Congrats!")


### PR DESCRIPTION
The purpose of this pull request is for giving suggestions instead of looking for a real pull.

It seems like the book (up to chapter 7 that I've read so far) as well as PTAN's documentation doesn't give a complete explanation of what 'pop_rewards_steps' function does. My guess for the 'steps' variable returned by this function is the amount of steps executed in each episode, although I am still unsure for that (no time to read through the source code, sorry). If that's the case, the print operation written in this way might be clearer.

Besides, for 'EpsilonGreedyActionSelector', you explicitly create a 'ArgmaxActionSelector' as its argument, which I think is good because it reminds readers the flexibility of PTAN even though 'ArgmaxActionSelector' is already the default choice in the source code. But for 'ExperienceSourceFirstLast', you didn't do similar things but rather let readers figure out the default choice for 'steps_count' is actually 1 and we are doing one step DQN. Therefore, I think explicitly assigning the value 1 to this variable might be a good idea for pedagogical purpose.