### PR TITLE
I figured they wanted to use the agent environment and not the global variable

### DIFF
--- a/Chapter06/02_dqn_pong.py
+++ b/Chapter06/02_dqn_pong.py
@@ -62,7 +62,7 @@ class Agent:
         self._reset()
 
     def _reset(self):
-        self.state = env.reset()
+        self.state = self.env.reset()
         self.total_reward = 0.0
 
     @torch.no_grad()
@@ -70,7 +70,7 @@ class Agent:
         done_reward = None
 
         if np.random.random() < epsilon:
-            action = env.action_space.sample()
+            action = self.env.action_space.sample()
         else:
             state_a = np.array([self.state], copy=False)
             state_v = torch.tensor(state_a).to(device)


### PR DESCRIPTION
In the agent class we use the variable env defined in main instead of the one in the Agent class. It works in this case because the class is in the same file and that it is the same environment, but it would make sense to use the variable self.env instead of env