### PR TITLE
Fix: missing self in env accessed from play_step

### DIFF
--- a/Chapter06/02_dqn_pong.py
+++ b/Chapter06/02_dqn_pong.py
@@ -70,7 +70,7 @@ class Agent:
         done_reward = None
 
         if np.random.random() < epsilon:
-            action = env.action_space.sample()
+            action = self.env.action_space.sample()
         else:
             state_a = np.array([self.state], copy=False)
             state_v = torch.tensor(state_a).to(device)


### PR DESCRIPTION
Minor change, env was called in play_step method of Agent class without self.