### PR TITLE
Fix bug: Chapter06, RuntimeError: gather_out_cpu(): Expected dtype int64 for index

### DIFF
--- a/Chapter06/02_dqn_pong.py
+++ b/Chapter06/02_dqn_pong.py
@@ -99,7 +99,7 @@ def calc_loss(batch, net, tgt_net, device="cpu"):
         states, copy=False)).to(device)
     next_states_v = torch.tensor(np.array(
         next_states, copy=False)).to(device)
-    actions_v = torch.tensor(actions).to(device)
+    actions_v = torch.tensor(actions, dtype=torch.int64).to(device)
     rewards_v = torch.tensor(rewards).to(device)
     done_mask = torch.BoolTensor(dones).to(device)
 


### PR DESCRIPTION
When I run the ```Chapter06\02_dqn_pong.py``` script，I get the following error:
```
Traceback (most recent call last):
  File "d:/code/Deep-Reinforcement-Learning-Hands-On-Second-Edition/Chapter06/02_dqn_pong.py", line 189, in <module>
    loss_t = calc_loss(batch, net, tgt_net, device=device)
  File "d:/code/Deep-Reinforcement-Learning-Hands-On-Second-Edition/Chapter06/02_dqn_pong.py", line 107, in calc_loss
    1, actions_v.unsqueeze(-1)).squeeze(-1)
RuntimeError: gather_out_cpu(): Expected dtype int64 for index
```
I found that this error was mentioned in an issue(#45) and a solution was given.